### PR TITLE
Add Logseq Schrodinger to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ See <https://xyhp915.github.io/logseq-marketplace-table/> and filter to `Themes`
 - [logseq-plugin-ai-query](https://github.com/dailydaniel/logseq-plugin-ai-query) - AI generation of advanced queries
 - [logseq-plugin-copilot](https://github.com/chhabrakadabra/logseq-plugin-copilot) by chhabrakadabra - Talk to AI about your Logseq notes.
 - [logseq-insert-random-pages](https://github.com/wonyoung-jang/logseq-insert-random-pages) by Wonyoung Jang - Insert random pages as blocks.
+- [Logseq Schrödinger](https://github.com/sawhney17/logseq-schrodinger) by sawhney17 -  A plugin to export pages in Logseq to Hugo. 
 
 See <https://xyhp915.github.io/logseq-marketplace-table/> and filter to `Plugins` for a full list
 


### PR DESCRIPTION
Logseq Schrodinger is a cool plugin which allows exporting logseq pages to a Hugo-based website.